### PR TITLE
fix flow, add euid check & report

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,35 @@
-# About this script
+## About
 The script is designed to remove Snap packages and the Snapd service from an Ubuntu system and replace it with Firefox from Mozilla's APT repository. It first prompts the user for confirmation before removing Snap packages and the Snapd service, including stopping and disabling the Snapd service, purging the Snapd package, and deleting Snap-related directories. After Snap is removed, it creates a preference file to prevent Snapd from being reinstalled. The script then prompts the user again to confirm if they want to install Firefox, adds Mozilla’s APT repository, and installs Firefox. Lastly, it optionally installs the Gnome App Store if the user agrees. The script includes error handling to ensure each step completes successfully and provides feedback if something goes wrong.
 
-
-# how to run the script
+## How To Run
 1. _Save the Script_
-2. First, you need to download the script name **remove_snap.sh**
-3. Open a terminal and navigate to the directory where you saved the script. You need to make the script executable. You can do this using the chmod command: 
-```chmod +x remove_snap.sh```
-4.Now that the script is executable, you can run it. Use the following command:
-```./remove_snap.sh```
 
-# Which ubuntu ver it Support?
-it support every until now
+   1-1. Download the script name **remove_snap.sh**
 
-```take backup of system and use at ur own risk```
+   1-2. ...or clone this repo : \
+   ```git clone https://github.com/PagalSarthak/Remove-snap-in-ubuntu```
 
 
+2. Open a terminal and navigate to the directory where you saved the script.
+
+3. You need to make the script executable. You can do this using the chmod command : \
+   ```chmod +x remove_snap.sh ```
+
+4. Now that the script is executable, you can run it. \
+   Use the following command **(MUST RUN WITH ROOT PRIVILEGE FOR APT)** : \
+   ```sudo ./remove_snap.sh```
+
+## Optional Install
+- [Firefox](https://www.firefox.com/)
+    - [Extended Support Release](https://wiki.mozilla.org/Enterprise/Firefox/ExtendedSupport:Proposal) or Rapid(Normal) Release
+- [Gnome Software Center](https://apps.gnome.org/en/Software/)
+
+## Which Ubuntu Version It Support?
+It supports every Ubuntu version with snap until now.
+
+## Disclaimer
+Ubuntu is a registered trademark of Canonical Ltd.  
+This project is not affiliated with, endorsed by, or sponsored by Canonical Ltd or the Ubuntu project.
+
+---
+**TAKE BACKUP OF SYSTEM AND USE AT YOUR OWN RISK**

--- a/remove_snap.sh
+++ b/remove_snap.sh
@@ -136,7 +136,6 @@ if [ "$IS_FIREFOX" -eq 0 ] || [ "$IS_GNOME" -eq 0 ]; then
     else
       echo "    - Firefox"
     fi
-
   fi
 
   if [ "$IS_GNOME" -eq 0 ] ; then

--- a/remove_snap.sh
+++ b/remove_snap.sh
@@ -107,7 +107,6 @@ while snap list | awk 'NR > 1 {print $1}' | grep .; do
     echo "Waiting for Snap packages to be fully removed..."
     sleep 5
 done
-rm -rf ~/snap
 
 # Clean up Snap directories and create a preference file
 create_preference_file

--- a/remove_snap.sh
+++ b/remove_snap.sh
@@ -107,6 +107,7 @@ while snap list | awk 'NR > 1 {print $1}' | grep .; do
     echo "Waiting for Snap packages to be fully removed..."
     sleep 5
 done
+rm -rf ~/snap
 
 # Clean up Snap directories and create a preference file
 create_preference_file

--- a/remove_snap.sh
+++ b/remove_snap.sh
@@ -4,13 +4,18 @@ echo "thx for using our script"
 
 set -e
 
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run as root: sudo $0"
+  exit 1
+fi
+
 # Function to prompt for user confirmation
 prompt_confirmation() {
     while true; do
         read -p "$1 [y/n]: " choice
         case "$choice" in
             y|Y ) return 0;; # Yes
-            n|N ) echo "Operation aborted."; exit 1;; # No
+            n|N ) return 1;; # No
             * ) echo "Please answer yes or no.";;
         esac
     done
@@ -37,7 +42,7 @@ remove_snapd() {
     sudo systemctl stop snapd || true
     sudo systemctl disable snapd || true
     sudo systemctl mask snapd || true
-    
+
     echo "Removing Snapd service..."
     sudo apt-get purge -y snapd || true
 }
@@ -45,6 +50,11 @@ remove_snapd() {
 
 # Function to create a preference file to prevent Snap from being reinstalled
 create_preference_file() {
+    # check duplicated file
+    if [ -f /etc/apt/preferences.d/nosnap.pref ]; then
+      sudo rm /etc/apt/preferences.d/nosnap.pref
+    fi
+
     echo "Creating preference file to prevent Snap from being reinstalled..."
     echo "Package: snapd" | sudo tee /etc/apt/preferences.d/nosnap.pref > /dev/null
     echo "Pin: release a=*" | sudo tee -a /etc/apt/preferences.d/nosnap.pref > /dev/null
@@ -60,13 +70,22 @@ install_firefox() {
     echo "Package: *" | sudo tee /etc/apt/preferences.d/mozilla > /dev/null
     echo "Pin: origin packages.mozilla.org" | sudo tee -a /etc/apt/preferences.d/mozilla > /dev/null
     echo "Pin-Priority: 1000" | sudo tee -a /etc/apt/preferences.d/mozilla > /dev/null
-    sudo apt-get update && sudo apt-get install -y firefox || handle_error "Failed to install Firefox"
+
+    sudo apt-get -qq update
+
+    IS_FFESR=1
+    if prompt_confirmation "Do you want to install ESR Version?"; then
+      IS_FFESR=0
+      sudo apt-get install -qq -y firefox-esr || handle_error "Failed to install Firefox"
+    else
+      sudo apt-get install -qq -y firefox || handle_error "Failed to install Firefox"
+    fi
 }
 
 # Function to install GNOME Software
 install_gnome_software() {
     echo "Installing GNOME Software..."
-    sudo apt install -y gnome-software || handle_error "Failed to install GNOME Software"
+    sudo apt install -qq -y gnome-software || handle_error "Failed to install GNOME Software"
 }
 
 # Function to handle errors
@@ -74,6 +93,7 @@ handle_error() {
     echo "Error: $1"
     exit 1
 }
+
 
 # Main script execution
 echo "Starting Snap removal process..."
@@ -89,17 +109,41 @@ while snap list | awk 'NR > 1 {print $1}' | grep .; do
 done
 
 # Clean up Snap directories and create a preference file
-
 create_preference_file
 
+IS_FIREFOX=1
 # Prompt for confirmation to install Firefox
-prompt_confirmation "Do you want to add Mozilla's APT repository and install Firefox?"
+if prompt_confirmation "Do you want to add Mozilla's APT repository and install Firefox?"; then
+  IS_FIREFOX=0
+  install_firefox
+fi
 
-install_firefox
-
+IS_GNOME=1
 # Prompt for confirmation to install GNOME Software
-prompt_confirmation "Do you want to install GNOME Software?"
+if prompt_confirmation "Do you want to install GNOME Software?"; then
+  IS_GNOME=0
+  install_gnome_software
+fi
 
-install_gnome_software
+# report of removal and installation process
+echo "========================================"
+echo "  Snap removal process completed."
 
-echo "Snap removal process completed. Firefox and GNOME Software have been installed."
+if [ "$IS_FIREFOX" -eq 0 ] || [ "$IS_GNOME" -eq 0 ]; then
+  if [ "$IS_FIREFOX" -eq 0 ]; then
+    if [ "$IS_FFESR" -eq 0 ]; then
+      echo "    - Firefox ESR"
+    else
+      echo "    - Firefox"
+    fi
+
+  fi
+
+  if [ "$IS_GNOME" -eq 0 ] ; then
+    echo "    - GNOME Software"
+  fi
+
+  echo "  has been installed."
+fi
+
+echo "========================================"


### PR DESCRIPTION
## Script
### Fixed
- Unintended flow when installing optional software
User cannot do install gnome software only (skip firefox), because function prompt_confirmation() do ```exit 1```
-> Added if-else statement and variable to handle branch
- No check for previously created ```/etc/apt/preferences.d/nosnap.pref```
-> Added check-and-delete to avoid problems (just in case)

### Added
- Checking EUID at very top of script to prevent situation that user input password for ```sudo apt``` during script
- Option to select Firefox release (ESR or Rapid)
- Reporting installed software during script before exit by checking variable IS_FIREFOX, IS_GNOME, IS_FFESR

## Readme
### Fixed
- How to(guide) as changes of script
- Some informal words

### Added
- **Disclaimer about Ubuntu**
Canonical is pushing snap currently so **this project can rub Cannonical somehow wrong**


Looking forward to having my PR accepted, thanks.